### PR TITLE
Set Silero default voice to female 'xenia'

### DIFF
--- a/options/plugin_tts_silero_v3.json
+++ b/options/plugin_tts_silero_v3.json
@@ -1,11 +1,11 @@
 {
-    "speaker": "baya",
+    "speaker": "xenia",
     "threads": 4,
     "sample_rate": 48000,
     "put_accent": true,
     "put_yo": true,
     "speaker_by_assname": {
-        "ирина|ирины|ирину": "baya",
-        "альбина|альбине": "xenia"
+        "ирина|ирины|ирину": "xenia",
+        "альбина|альбине": "baya"
     }
 }

--- a/options/plugin_tts_silero_v4.json
+++ b/options/plugin_tts_silero_v4.json
@@ -1,11 +1,11 @@
 {
-    "speaker": "baya",
+    "speaker": "xenia",
     "threads": 4,
     "sample_rate": 48000,
     "put_accent": true,
     "put_yo": true,
     "speaker_by_assname": {
-        "ирина|ирины|ирину": "baya",
-        "альбина|альбине": "xenia"
+        "ирина|ирины|ирину": "xenia",
+        "альбина|альбине": "baya"
     }
 }

--- a/plugins/plugin_tts_silero_v3.py
+++ b/plugins/plugin_tts_silero_v3.py
@@ -24,14 +24,14 @@ def start(core:VACore):
         "require_online": False,
 
         "default_options": {
-            "speaker": "baya",
+            "speaker": "xenia",
             "threads": 4,
             "sample_rate": 48000,
             "put_accent": True,
             "put_yo": True,
             "speaker_by_assname": {
-                "ирина|ирины|ирину": "baya",
-                "альбина|альбине": "xenia",
+                "ирина|ирины|ирину": "xenia",
+                "альбина|альбине": "baya",
                 "николай|николаю": "aidar"
             }
         },

--- a/plugins/plugin_tts_silero_v4.py
+++ b/plugins/plugin_tts_silero_v4.py
@@ -24,14 +24,14 @@ def start(core:VACore):
         "require_online": False,
 
         "default_options": {
-            "speaker": "baya",
+            "speaker": "xenia",
             "threads": 4,
             "sample_rate": 48000,
             "put_accent": True,
             "put_yo": True,
             "speaker_by_assname": {
-                "ирина|ирины|ирину": "baya",
-                "альбина|альбине": "xenia",
+                "ирина|ирины|ирину": "xenia",
+                "альбина|альбине": "baya",
                 "николай|николаю": "aidar"
             }
         },


### PR DESCRIPTION
## Summary
- default Silero v3 and v4 TTS voices now use female speaker `xenia`
- update plugin configuration to reflect new default voice

## Testing
- `python test_plugins.py` *(fails: No module named 'dateutil', 'pyttsx3', 'sounddevice', 'openai', 'audioplayer', 'pyautogui')*

------
https://chatgpt.com/codex/tasks/task_e_68ac41856ba0832fb29883e74443021b